### PR TITLE
WIP: #4511 net / UDP transport "panic BorrowMutError" when send/receive asynchronously

### DIFF
--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -1622,23 +1622,23 @@ declare namespace Deno {
   /** **UNSTABLE**: new API, yet to be vetted.
    *
    * A generic transport listener for message-oriented protocols. */
-  export interface DatagramConn extends AsyncIterable<[Uint8Array, Addr]> {
+  export interface DatagramConn<A extends Addr> extends AsyncIterable<[Uint8Array, A]> {
     /** **UNSTABLE**: new API, yet to be vetted.
      *
      * Waits for and resolves to the next message to the `UDPConn`. */
-    receive(p?: Uint8Array): Promise<[Uint8Array, Addr]>;
+    receive(p?: Uint8Array): Promise<[Uint8Array, A]>;
     /** UNSTABLE: new API, yet to be vetted.
      *
      * Sends a message to the target. */
-    send(p: Uint8Array, addr: Addr): Promise<void>;
+    send(p: Uint8Array, addr: A): Promise<void>;
     /** UNSTABLE: new API, yet to be vetted.
      *
      * Close closes the socket. Any pending message promises will be rejected
      * with errors. */
     close(): void;
     /** Return the address of the `UDPConn`. */
-    readonly addr: Addr;
-    [Symbol.asyncIterator](): AsyncIterator<[Uint8Array, Addr]>;
+    readonly addr: A;
+    [Symbol.asyncIterator](): AsyncIterator<[Uint8Array, A]>;
   }
 
   /** A generic network listener for stream-oriented protocols. */
@@ -1714,7 +1714,7 @@ declare namespace Deno {
    * Requires `allow-net` permission. */
   export function listen(
     options: ListenOptions & { transport: "udp" }
-  ): DatagramConn;
+  ): DatagramConn<NetAddr>;
   /** **UNSTABLE**: new API
    *
    * Listen announces on the local transport address.
@@ -1724,7 +1724,7 @@ declare namespace Deno {
    * Requires `allow-read` permission. */
   export function listen(
     options: UnixListenOptions & { transport: "unixpacket" }
-  ): DatagramConn;
+  ): DatagramConn<UnixAddr>;
 
   export interface ListenTLSOptions extends ListenOptions {
     /** Server certificate file. */

--- a/cli/js/ops/net.ts
+++ b/cli/js/ops/net.ts
@@ -62,16 +62,16 @@ export function connect(args: ConnectRequest): Promise<ConnectResponse> {
   return sendAsync("op_connect", args);
 }
 
-interface ReceiveResponse {
+interface ReceiveResponse<A extends Addr> {
   size: number;
-  remoteAddr: Addr;
+  remoteAddr: A;
 }
 
-export function receive(
+export function receive<A extends Addr>(
   rid: number,
   transport: string,
   zeroCopy: Uint8Array
-): Promise<ReceiveResponse> {
+): Promise<ReceiveResponse<A>> {
   return sendAsync("op_receive", { rid, transport }, zeroCopy);
 }
 


### PR DESCRIPTION
WIP fix for #4511

### Changes
1. Move state borrows out of async blocks
2. Use immutable borrows
3. Split `UDPSocket` into send/receive halves contained within `Arc<Mutex<>>`
4. Tweaks to use generics with `DatagramImpl` for socket addresses.

### Tasks
- [ ] Review approach
- [ ] Write failing tests with master + more tests
